### PR TITLE
Bump ESLint and prettier dependencies

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,6 +9,6 @@ extends:
 
 rules:
   eqeqeq: error
-  no-console: warn
+  no-console: off # TODO: Set back to "warn"
   no-unused-vars: [error, {vars: all, args: none, ignoreRestSiblings: false}]
   no-warning-comments: warn

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ env:
 
 extends:
   - eslint:recommended
+  - plugin:mozilla/recommended
 
 rules:
   eqeqeq: error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,4 +11,6 @@ rules:
   eqeqeq: error
   no-console: off # TODO: Set back to "warn"
   no-unused-vars: [error, {vars: all, args: none, ignoreRestSiblings: false}]
+  no-var: error
   no-warning-comments: warn
+  prefer-const: error

--- a/extension/content.js
+++ b/extension/content.js
@@ -25,11 +25,11 @@
         // 22kHz or more, and we only care about visualizing lower frequencies
         // which is where most human voice lies, so we use fewer bins
         analyzerNode.fftSize = 64;
-        let frequencyBins = new Float32Array(14);
+        const frequencyBins = new Float32Array(14);
 
         // Clear the canvas
-        let levels = document.getElementById("stm-levels");
-        let context = levels.getContext("2d");
+        const levels = document.getElementById("stm-levels");
+        const context = levels.getContext("2d");
         context.clearRect(0, 0, levels.width, levels.height);
 
         if (levels.hidden) {
@@ -42,16 +42,16 @@
 
         // Display it as a barchart.
         // Drop bottom few bins, since they are often misleadingly high
-        let skip = 2;
-        let n = frequencyBins.length - skip;
-        let barwidth = levels.width / n;
-        let dbRange = MAX_DB_LEVEL - MIN_DB_LEVEL;
+        const skip = 2;
+        const n = frequencyBins.length - skip;
+        const barwidth = levels.width / n;
+        const dbRange = MAX_DB_LEVEL - MIN_DB_LEVEL;
 
         // Loop through the values and draw the bars
         context.fillStyle = "black";
         for (let i = 0; i < n; i++) {
-            let value = frequencyBins[i + skip];
-            let height = levels.height * (value - MIN_DB_LEVEL) / dbRange;
+            const value = frequencyBins[i + skip];
+            const height = levels.height * (value - MIN_DB_LEVEL) / dbRange;
             if (height < 0) {
                 continue;
             }
@@ -82,7 +82,7 @@
     const SpeakToMePopup = {
         init: () => {
             console.log(`SpeakToMePopup init`);
-            let popup = document.createElement("div");
+            const popup = document.createElement("div");
             popup.innerHTML = popup_markup;
             document.body.appendChild(popup);
             this.popup = document.getElementById("stm-popup");
@@ -92,9 +92,9 @@
         showAt: (x, y) => {
             console.log(`SpeakToMePopup showAt ${x},${y}`);
             this.list.classList.add("hidden");
-            let style = this.popup.style;
+            const style = this.popup.style;
             style.display = "block";
-            let bcr = this.popup.getBoundingClientRect();
+            const bcr = this.popup.getBoundingClientRect();
             style.left = x + window.scrollX - bcr.width / 2 + "px";
             style.top = y + window.scrollY - bcr.width / 2 + "px";
         },
@@ -110,8 +110,8 @@
             console.log(`SpeakToMePopup wait_for_stop`);
             return new Promise((resolve, reject) => {
                 console.log(`SpeakToMePopup set popup stop listener`);
-                let button = document.getElementById("stm-stop");
-                let popup = document.getElementById("stm-popup");
+                const button = document.getElementById("stm-stop");
+                const popup = document.getElementById("stm-popup");
                 button.classList.remove("hidden");
                 popup.addEventListener("click", function _mic_stop() {
                     button.classList.add("hidden");
@@ -130,7 +130,7 @@
                     html += `<li>${item.text}</li>`;
                 });
                 html += "</ul>";
-                let list = this.list;
+                const list = this.list;
                 list.innerHTML = html;
                 list.classList.remove("hidden");
 
@@ -156,7 +156,7 @@
         constructor() {
             console.log(`SpeakToMeIcon constructor ${this}`);
             this.icon = document.createElement("div");
-            let mic = document.createElement("img");
+            const mic = document.createElement("img");
             mic.src = mic_icon_url;
             this.icon.appendChild(mic);
             this.icon.classList.add("stm-icon");
@@ -165,7 +165,7 @@
 
             this.icon.addEventListener("click", on_spm_icon_click);
 
-            let self = this;
+            const self = this;
             document.body.addEventListener("focusin", event => {
                 self.anchor_to(event.target);
             });
@@ -179,14 +179,14 @@
         // Checks if the input field moved around and if we need to
         // reposition the icon.
         update_pos() {
-            let bcr = this._input_field.getBoundingClientRect();
+            const bcr = this._input_field.getBoundingClientRect();
             // Position the mic at the end of the input field.
-            let left =
+            const left =
                 bcr.width + bcr.left + window.scrollX - mic_icon_width + "px";
             if (left !== this.icon.style.left) {
                 this.icon.style.left = left;
             }
-            let top =
+            const top =
                 bcr.top +
                 window.scrollY +
                 (bcr.height - mic_icon_height) / 2 +
@@ -228,7 +228,7 @@
     }
 
     const on_spm_icon_click = event => {
-        let constraints = { audio: true };
+        const constraints = { audio: true };
         let chunks = [];
 
         navigator.mediaDevices
@@ -247,14 +247,14 @@
                 sourceNode.connect(analyzerNode);
                 analyzerNode.connect(outputNode);
                 // and set up the recorder
-                let options = {
+                const options = {
                     audioBitsPerSecond: 16000,
                     mimeType: "audio/ogg"
                 };
 
                 // VAD initializations
                 // console.log("Sample rate: ", audioContext.sampleRate);
-                let bufferSize = 2048;
+                const bufferSize = 2048;
                 // create a javascript node
                 let scriptprocessor = audioContext.createScriptProcessor(
                     bufferSize,
@@ -302,13 +302,13 @@
                     stream = null;
                     scriptprocessor = null;
 
-                    let blob = new Blob(chunks, {
+                    const blob = new Blob(chunks, {
                         type: "audio/ogg; codecs=opus"
                     });
                     chunks = [];
 
                     if (LOCAL_TEST) {
-                        let json = JSON.parse(
+                        const json = JSON.parse(
                             '{"status":"ok","data":[{"confidence":0.807493,"text":"PLEASE ADD MILK TO MY SHOPPING LIST"},{"confidence":0.906263,"text":"PLEASE AT MILK TO MY SHOPPING LIST"},{"confidence":0.904414,"text":"PLEASE ET MILK TO MY SHOPPING LIST"}]}'
                         );
                         if (json.status === "ok") {
@@ -348,7 +348,7 @@
 
     const display_options = items => {
         // Filter the array for empty items and normalize the text.
-        let data = items
+        const data = items
             .filter(item => {
                 return item.text !== "";
             })
@@ -382,7 +382,7 @@
 
     SpeakToMePopup.init();
 
-    let stm_icon = new SpeakToMeIcon();
+    const stm_icon = new SpeakToMeIcon();
 
     // Webrtc_Vad integration
     SpeakToMeVad = function SpeakToMeVad() {
@@ -426,17 +426,17 @@
         // function that returns if the specified buffer has silence of speech
         this.isSilence = function(buffer_pcm) {
             // Get data byte size, allocate memory on Emscripten heap, and get pointer
-            let nDataBytes = buffer_pcm.length * buffer_pcm.BYTES_PER_ELEMENT;
-            let dataPtr = Module._malloc(nDataBytes);
+            const nDataBytes = buffer_pcm.length * buffer_pcm.BYTES_PER_ELEMENT;
+            const dataPtr = Module._malloc(nDataBytes);
             // Copy data to Emscripten heap (directly accessed from Module.HEAPU8)
-            let dataHeap = new Uint8Array(
+            const dataHeap = new Uint8Array(
                 Module.HEAPU8.buffer,
                 dataPtr,
                 nDataBytes
             );
             dataHeap.set(new Uint8Array(buffer_pcm.buffer));
             // Call function and get result
-            let result = this.webrtc_process_data(
+            const result = this.webrtc_process_data(
                 dataHeap.byteOffset,
                 buffer_pcm.length,
                 48000,
@@ -451,13 +451,13 @@
 
         this.floatTo16BitPCM = function(output, input) {
             for (let i = 0; i < input.length; i++) {
-                let s = Math.max(-1, Math.min(1, input[i]));
+                const s = Math.max(-1, Math.min(1, input[i]));
                 output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
             }
         };
 
         this.recorderProcess = function(e) {
-            let buffer_pcm = new Int16Array(
+            const buffer_pcm = new Int16Array(
                 e.inputBuffer.getChannelData(0).length
             );
             stm_vad.floatTo16BitPCM(
@@ -471,7 +471,7 @@
                 !stm_vad.done;
                 i++
             ) {
-                let start = i * stm_vad.sizeBufferVad;
+                const start = i * stm_vad.sizeBufferVad;
                 let end = start + stm_vad.sizeBufferVad;
                 if (start + stm_vad.sizeBufferVad > buffer_pcm.length) {
                     // store to the next buffer
@@ -490,9 +490,9 @@
                         // send to the vad
                         stm_vad.buffer_vad.set(buffer_pcm.slice(start, end));
                     }
-                    let vad = stm_vad.isSilence(stm_vad.buffer_vad);
+                    const vad = stm_vad.isSilence(stm_vad.buffer_vad);
                     stm_vad.buffer_vad = new Int16Array(stm_vad.sizeBufferVad);
-                    let dtdepois = Date.now();
+                    const dtdepois = Date.now();
                     if (vad === 0) {
                         if (stm_vad.touchedvoice) {
                             stm_vad.samplessilence +=
@@ -567,7 +567,7 @@ var Module = {
         );
     }
 };
-var stm_vad;
+let stm_vad;
 Module.setStatus("Loading webrtc_vad...");
 window.onerror = function(event) {
     // TODO: do not warn on ok events like simulating an infinite loop or exitStatus

--- a/extension/content.js
+++ b/extension/content.js
@@ -3,68 +3,75 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 (function speak_to_me() {
+    console.log("Speak To Me starting up...");
 
-console.log("Speak To Me starting up...");
-
-if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-    console.error("You need a browser with getUserMedia support to use Speak To Me, sorry!");
-    return;
-}
-
-const LOCAL_TEST = false;
-
-const stt_server_url = "http://54.183.226.82:9001/asr";
-
-function visualize(analyzerNode) {
-    const MIN_DB_LEVEL = -85;      // The dB level that is 0 in the levels display
-    const MAX_DB_LEVEL = -30;      // The dB level that is 100% in the levels display
-
-    // Set up the analyzer node, and allocate an array for its data
-    // FFT size 64 gives us 32 bins. But those bins hold frequencies up to
-    // 22kHz or more, and we only care about visualizing lower frequencies
-    // which is where most human voice lies, so we use fewer bins
-    analyzerNode.fftSize = 64;
-    let frequencyBins = new Float32Array(14);
-
-    // Clear the canvas
-    let levels = document.getElementById("stm-levels");
-    let context = levels.getContext("2d");
-    context.clearRect(0, 0, levels.width, levels.height);
-
-    if (levels.hidden) {
-        // If we've been hidden, return right away without calling rAF again.
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        console.error(
+            "You need a browser with getUserMedia support to use Speak To Me, sorry!"
+        );
         return;
     }
 
-    // Get the FFT data
-    analyzerNode.getFloatFrequencyData(frequencyBins);
+    const LOCAL_TEST = false;
 
-    // Display it as a barchart.
-    // Drop bottom few bins, since they are often misleadingly high
-    let skip = 2;
-    let n = frequencyBins.length - skip;
-    let barwidth = levels.width / n;
-    let dbRange = MAX_DB_LEVEL - MIN_DB_LEVEL;
+    const stt_server_url = "http://54.183.226.82:9001/asr";
 
-    // Loop through the values and draw the bars
-    context.fillStyle = "black";
-    for (let i = 0; i < n; i++) {
-        let value = frequencyBins[i + skip];
-        let height = levels.height * (value - MIN_DB_LEVEL) / dbRange;
-        if (height < 0) {
-            continue;
+    function visualize(analyzerNode) {
+        const MIN_DB_LEVEL = -85; // The dB level that is 0 in the levels display
+        const MAX_DB_LEVEL = -30; // The dB level that is 100% in the levels display
+
+        // Set up the analyzer node, and allocate an array for its data
+        // FFT size 64 gives us 32 bins. But those bins hold frequencies up to
+        // 22kHz or more, and we only care about visualizing lower frequencies
+        // which is where most human voice lies, so we use fewer bins
+        analyzerNode.fftSize = 64;
+        let frequencyBins = new Float32Array(14);
+
+        // Clear the canvas
+        let levels = document.getElementById("stm-levels");
+        let context = levels.getContext("2d");
+        context.clearRect(0, 0, levels.width, levels.height);
+
+        if (levels.hidden) {
+            // If we've been hidden, return right away without calling rAF again.
+            return;
         }
-        // Display a bar for this value.
-        context.fillRect(i * barwidth, (levels.height - height) / 2, barwidth / 2, height);
+
+        // Get the FFT data
+        analyzerNode.getFloatFrequencyData(frequencyBins);
+
+        // Display it as a barchart.
+        // Drop bottom few bins, since they are often misleadingly high
+        let skip = 2;
+        let n = frequencyBins.length - skip;
+        let barwidth = levels.width / n;
+        let dbRange = MAX_DB_LEVEL - MIN_DB_LEVEL;
+
+        // Loop through the values and draw the bars
+        context.fillStyle = "black";
+        for (let i = 0; i < n; i++) {
+            let value = frequencyBins[i + skip];
+            let height = levels.height * (value - MIN_DB_LEVEL) / dbRange;
+            if (height < 0) {
+                continue;
+            }
+            // Display a bar for this value.
+            context.fillRect(
+                i * barwidth,
+                (levels.height - height) / 2,
+                barwidth / 2,
+                height
+            );
+        }
+
+        // Update the visualization the next time we can
+        requestAnimationFrame(function() {
+            visualize(analyzerNode);
+        });
     }
 
-    // Update the visualization the next time we can
-    requestAnimationFrame(function() { visualize(analyzerNode); });
-}
-
-// Encapsulation of the popup we use to provide our UI.
-const popup_markup =
-`
+    // Encapsulation of the popup we use to provide our UI.
+    const popup_markup = `
 <div id="stm-popup">
   <span id="stm-stop">Speak To Me…</span>
   <div id="stm-divlevels"> <canvas hidden id="stm-levels" width=150 height=50></canvas></div>
@@ -72,400 +79,461 @@ const popup_markup =
 </div>
 `;
 
-const SpeakToMePopup = {
-    init: () => {
-        console.log(`SpeakToMePopup init`);
-        let popup = document.createElement("div");
-        popup.innerHTML = popup_markup;
-        document.body.appendChild(popup);
-        this.popup = document.getElementById("stm-popup");
-        this.list = document.getElementById("stm-list");
-    },
+    const SpeakToMePopup = {
+        init: () => {
+            console.log(`SpeakToMePopup init`);
+            let popup = document.createElement("div");
+            popup.innerHTML = popup_markup;
+            document.body.appendChild(popup);
+            this.popup = document.getElementById("stm-popup");
+            this.list = document.getElementById("stm-list");
+        },
 
-    showAt: (x, y) => {
-        console.log(`SpeakToMePopup showAt ${x},${y}`);
-        this.list.classList.add("hidden");
-        let style = this.popup.style;
-        style.display = "block";
-        let bcr = this.popup.getBoundingClientRect();
-        style.left = (x + window.scrollX - bcr.width / 2) + "px";
-        style.top = (y + window.scrollY - bcr.width / 2) + "px";
-    },
+        showAt: (x, y) => {
+            console.log(`SpeakToMePopup showAt ${x},${y}`);
+            this.list.classList.add("hidden");
+            let style = this.popup.style;
+            style.display = "block";
+            let bcr = this.popup.getBoundingClientRect();
+            style.left = x + window.scrollX - bcr.width / 2 + "px";
+            style.top = y + window.scrollY - bcr.width / 2 + "px";
+        },
 
-    hide: () => {
-        console.log(`SpeakToMePopup hide`);
-        this.popup.style.display = "none";
-    },
+        hide: () => {
+            console.log(`SpeakToMePopup hide`);
+            this.popup.style.display = "none";
+        },
 
-    // Returns a Promise that resolves once the "Stop" button is clicked.
-    // TODO: replace with silence detection.
-    wait_for_stop: () => {
-        console.log(`SpeakToMePopup wait_for_stop`);
-        return new Promise((resolve, reject) => {
-            console.log(`SpeakToMePopup set popup stop listener`);
-            let button = document.getElementById("stm-stop");
-            let popup = document.getElementById("stm-popup");
-            button.classList.remove("hidden");
-            popup.addEventListener("click", function _mic_stop() {
-                button.classList.add("hidden");
-                popup.removeEventListener("click", _mic_stop);
-                resolve();
+        // Returns a Promise that resolves once the "Stop" button is clicked.
+        // TODO: replace with silence detection.
+        wait_for_stop: () => {
+            console.log(`SpeakToMePopup wait_for_stop`);
+            return new Promise((resolve, reject) => {
+                console.log(`SpeakToMePopup set popup stop listener`);
+                let button = document.getElementById("stm-stop");
+                let popup = document.getElementById("stm-popup");
+                button.classList.remove("hidden");
+                popup.addEventListener("click", function _mic_stop() {
+                    button.classList.add("hidden");
+                    popup.removeEventListener("click", _mic_stop);
+                    resolve();
+                });
             });
-        });
-    },
+        },
 
-    // Returns a Promise that resolves to the choosen text.
-    choose_item: (data) => {
-        console.log(`SpeakToMePopup choose_item`);
-        return new Promise((resolve, reject) => {
-            let html = "<ul class='stm-list'>";
-            data.forEach(item => {
-                html += `<li>${item.text}</li>`;
+        // Returns a Promise that resolves to the choosen text.
+        choose_item: data => {
+            console.log(`SpeakToMePopup choose_item`);
+            return new Promise((resolve, reject) => {
+                let html = "<ul class='stm-list'>";
+                data.forEach(item => {
+                    html += `<li>${item.text}</li>`;
+                });
+                html += "</ul>";
+                let list = this.list;
+                list.innerHTML = html;
+                list.classList.remove("hidden");
+
+                list.addEventListener("click", function _choose_item(e) {
+                    list.removeEventListener("click", _choose_item);
+                    if (e.target instanceof HTMLLIElement) {
+                        resolve(e.target.textContent);
+                    }
+                });
             });
-            html += "</ul>";
-            let list = this.list;
-            list.innerHTML = html;
-            list.classList.remove("hidden");
+        }
+    };
 
-            list.addEventListener("click", function _choose_item(e) {
-                list.removeEventListener("click", _choose_item);
-                if (e.target instanceof HTMLLIElement) {
-                    resolve(e.target.textContent);
-                }
+    // The icon that we anchor to the currently focused input element.
+
+    // TODO: figure out why using a resource in the extensions with browser.extension.getURL() fails.
+    const mic_icon_url =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAQAAABLCVATAAABW0lEQVR4Ad2VJXQDMRyHU1Ljzeu6+tnKeTM7NmPUu9CYSQ38ewVXWd/5t7qaoRrz/kkuNyoz/b5cOF+vjMoS7tqY2ohuPG9EZevIW7Ph2AhuwA/BvFXrQ+vwj6F8RZE4USRf0VOc6DlP0RrEUzeiVYij4qIViKPiomWII1/REsRTadEixFNp0QLEk8vhO3WAu8z+RZzoQs2yRrP/mkHEzzhwYG6zf8LhH0dqlnrMHbFMIr+5bUT1mZs//NE8aD0bN0f+DCLWy0AS4y5z5GU35hhk69V/ByxmjnsziRrZDQXJoh7TZtpN5+TVbI0X1arUNqJMYSMUFGw8ydq4tTaCMofYSYiASUC/KpbETQLWfIjYUTahzSRMwOKUHBiUHMgWLMK0OYd/WLyDIQkfeIe7UG7BnSSAP/5KSIB6UH7B7bhLa2TbgQqLAYq4yYqK8IchX59i3BGdfzAoqsEI9//IsA+uNg0AAAAASUVORK5CYII=";
+    const mic_icon_width = 36;
+    const mic_icon_height = 36;
+
+    class SpeakToMeIcon {
+        constructor() {
+            console.log(`SpeakToMeIcon constructor ${this}`);
+            this.icon = document.createElement("div");
+            let mic = document.createElement("img");
+            mic.src = mic_icon_url;
+            this.icon.appendChild(mic);
+            this.icon.classList.add("stm-icon");
+            this.icon.classList.add("hidden");
+            document.body.appendChild(this.icon);
+
+            this.icon.addEventListener("click", on_spm_icon_click);
+
+            let self = this;
+            document.body.addEventListener("focusin", event => {
+                self.anchor_to(event.target);
             });
-        });
-    }
-}
 
-// The icon that we anchor to the currently focused input element.
+            // Check if an element is already focused in the document.
+            if (document.hasFocus() && document.activeElement) {
+                self.anchor_to(document.activeElement);
+            }
+        }
 
-// TODO: figure out why using a resource in the extensions with browser.extension.getURL() fails.
-const mic_icon_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAQAAABLCVATAAABW0lEQVR4Ad2VJXQDMRyHU1Ljzeu6+tnKeTM7NmPUu9CYSQ38ewVXWd/5t7qaoRrz/kkuNyoz/b5cOF+vjMoS7tqY2ohuPG9EZevIW7Ph2AhuwA/BvFXrQ+vwj6F8RZE4USRf0VOc6DlP0RrEUzeiVYij4qIViKPiomWII1/REsRTadEixFNp0QLEk8vhO3WAu8z+RZzoQs2yRrP/mkHEzzhwYG6zf8LhH0dqlnrMHbFMIr+5bUT1mZs//NE8aD0bN0f+DCLWy0AS4y5z5GU35hhk69V/ByxmjnsziRrZDQXJoh7TZtpN5+TVbI0X1arUNqJMYSMUFGw8ydq4tTaCMofYSYiASUC/KpbETQLWfIjYUTahzSRMwOKUHBiUHMgWLMK0OYd/WLyDIQkfeIe7UG7BnSSAP/5KSIB6UH7B7bhLa2TbgQqLAYq4yYqK8IchX59i3BGdfzAoqsEI9//IsA+uNg0AAAAASUVORK5CYII=";
-const mic_icon_width = 36;
-const mic_icon_height = 36;
+        // Checks if the input field moved around and if we need to
+        // reposition the icon.
+        update_pos() {
+            let bcr = this._input_field.getBoundingClientRect();
+            // Position the mic at the end of the input field.
+            let left =
+                bcr.width + bcr.left + window.scrollX - mic_icon_width + "px";
+            if (left !== this.icon.style.left) {
+                this.icon.style.left = left;
+            }
+            let top =
+                bcr.top +
+                window.scrollY +
+                (bcr.height - mic_icon_height) / 2 +
+                "px";
+            if (top !== this.icon.style.top) {
+                this.icon.style.top = top;
+            }
+            requestAnimationFrame(this.update_pos.bind(this));
+        }
 
-class SpeakToMeIcon {
-    constructor() {
-        console.log(`SpeakToMeIcon constructor ${this}`);
-        this.icon = document.createElement("div");
-        let mic = document.createElement("img");
-        mic.src = mic_icon_url;
-        this.icon.appendChild(mic);
-        this.icon.classList.add("stm-icon");
-        this.icon.classList.add("hidden");
-        document.body.appendChild(this.icon);
+        anchor_to(target) {
+            console.log(`SpeakToMeIcon anchor_to ${target}`);
 
-        this.icon.addEventListener("click", on_spm_icon_click);
+            if (
+                !(
+                    target instanceof HTMLInputElement &&
+                    ["text", "email", "search"].indexOf(target.type) >= 0
+                )
+            ) {
+                return;
+            }
 
-        let self = this;
-        document.body.addEventListener("focusin", (event) => {
-            self.anchor_to(event.target);
-        });
+            if (this._input_field) {
+                this._input_field.classList.remove("stm-focused");
+            }
 
-        // Check if an element is already focused in the document.
-        if (document.hasFocus() && document.activeElement) {
-            self.anchor_to(document.activeElement);
+            this.icon.classList.remove("hidden");
+            this._input_field = target;
+            this._input_field.classList.add("stm-focused");
+
+            requestAnimationFrame(this.update_pos.bind(this));
+        }
+
+        set_input(text) {
+            console.log(`SpeakToMeIcon set_input ${text}`);
+            this._input_field.value = text;
+            this._input_field.focus();
         }
     }
 
-    // Checks if the input field moved around and if we need to
-    // reposition the icon.
-    update_pos() {
-        let bcr = this._input_field.getBoundingClientRect();
-        // Position the mic at the end of the input field.
-        let left = (bcr.width + bcr.left + window.scrollX - mic_icon_width) + "px";
-        if (left != this.icon.style.left) {
-            this.icon.style.left = left;
-        }
-        let top = (bcr.top + window.scrollY + (bcr.height - mic_icon_height) / 2) + "px";
-        if (top != this.icon.style.top) {
-            this.icon.style.top = top;
-        }
-        requestAnimationFrame(this.update_pos.bind(this));
-    }
+    const on_spm_icon_click = event => {
+        let constraints = { audio: true };
+        let chunks = [];
 
-    anchor_to(target) {
-        console.log(`SpeakToMeIcon anchor_to ${target}`);
+        navigator.mediaDevices
+            .getUserMedia(constraints)
+            .then(function(stream) {
+                // Build the WebAudio graph we'll be using
+                let audioContext = new AudioContext();
+                let sourceNode = audioContext.createMediaStreamSource(stream);
+                let analyzerNode = audioContext.createAnalyser();
+                let outputNode = audioContext.createMediaStreamDestination();
+                // make sure we're doing mono everywhere
+                sourceNode.channelCount = 1;
+                analyzerNode.channelCount = 1;
+                outputNode.channelCount = 1;
+                // connect the nodes together
+                sourceNode.connect(analyzerNode);
+                analyzerNode.connect(outputNode);
+                // and set up the recorder
+                let options = {
+                    audioBitsPerSecond: 16000,
+                    mimeType: "audio/ogg"
+                };
 
-        if (!(target instanceof HTMLInputElement &&
-            ["text", "email", "search"].indexOf(target.type) >= 0)) {
+                // VAD initializations
+                // console.log("Sample rate: ", audioContext.sampleRate);
+                let bufferSize = 2048;
+                // create a javascript node
+                let scriptprocessor = audioContext.createScriptProcessor(
+                    bufferSize,
+                    1,
+                    1
+                );
+                // specify the processing function
+                stm_vad.reset();
+                scriptprocessor.onaudioprocess = stm_vad.recorderProcess;
+                stm_vad.stopGum = () => {
+                    console.log("stopGum");
+                    mediaRecorder.stop();
+                    sourceNode.disconnect(scriptprocessor);
+                    sourceNode.disconnect(analyzerNode);
+                    analyzerNode.disconnect(outputNode);
+                };
+                // connect stream to our recorder
+                sourceNode.connect(scriptprocessor);
+
+                // MediaRecorder initialization
+                let mediaRecorder = new MediaRecorder(
+                    outputNode.stream,
+                    options
+                );
+                SpeakToMePopup.showAt(event.clientX, event.clientY);
+
+                SpeakToMePopup.wait_for_stop().then(() => {
+                    mediaRecorder.stop();
+                });
+
+                document.getElementById("stm-levels").hidden = false;
+                visualize(analyzerNode);
+
+                mediaRecorder.start();
+
+                mediaRecorder.onstop = e => {
+                    document.getElementById("stm-levels").hidden = true;
+                    console.log("mediaRecorder onStop");
+                    // We stopped the recording, send the content to the STT server.
+                    mediaRecorder = null;
+                    audioContext = null;
+                    sourceNode = null;
+                    analyzerNode = null;
+                    outputNode = null;
+                    stream = null;
+                    scriptprocessor = null;
+
+                    let blob = new Blob(chunks, {
+                        type: "audio/ogg; codecs=opus"
+                    });
+                    chunks = [];
+
+                    if (LOCAL_TEST) {
+                        let json = JSON.parse(
+                            '{"status":"ok","data":[{"confidence":0.807493,"text":"PLEASE ADD MILK TO MY SHOPPING LIST"},{"confidence":0.906263,"text":"PLEASE AT MILK TO MY SHOPPING LIST"},{"confidence":0.904414,"text":"PLEASE ET MILK TO MY SHOPPING LIST"}]}'
+                        );
+                        if (json.status === "ok") {
+                            display_options(json.data);
+                        }
+                        return;
+                    }
+
+                    fetch(stt_server_url, {
+                        method: "POST",
+                        body: blob
+                    })
+                        .then(response => {
+                            return response.json();
+                        })
+                        .then(json => {
+                            console.log(
+                                `Got STT result: ${JSON.stringify(json)}`
+                            );
+                            if (json.status === "ok") {
+                                display_options(json.data);
+                            }
+                        })
+                        .catch(error => {
+                            console.error(`Fetch error: ${error}`);
+                        });
+                };
+
+                mediaRecorder.ondataavailable = e => {
+                    chunks.push(e.data);
+                };
+            })
+            .catch(function(err) {
+                console.log(`Recording error: ${err}`);
+            });
+    };
+
+    const display_options = items => {
+        // Filter the array for empty items and normalize the text.
+        let data = items
+            .filter(item => {
+                return item.text !== "";
+            })
+            .map(item => {
+                return {
+                    confidence: item.confidence,
+                    text: item.text.toLowerCase()
+                };
+            });
+
+        if (data.length === 0) {
+            // TODO: display some failure notification to the user?
+            SpeakToMePopup.hide();
             return;
         }
 
-        if (this._input_field) {
-            this._input_field.classList.remove("stm-focused");
+        // if the first result has a high enough confidence, just
+        // use it directly.
+        if (data[0].confidence > 0.9) {
+            stm_icon.set_input(data[0].text);
+            SpeakToMePopup.hide();
+            return;
         }
 
-        this.icon.classList.remove("hidden");
-        this._input_field = target;
-        this._input_field.classList.add("stm-focused");
+        SpeakToMePopup.choose_item(data).then(text => {
+            stm_icon.set_input(text);
+            // Once a choice is made, close the popup.
+            SpeakToMePopup.hide();
+        });
+    };
 
-        requestAnimationFrame(this.update_pos.bind(this));
-    }
+    SpeakToMePopup.init();
 
-    set_input(text) {
-        console.log(`SpeakToMeIcon set_input ${text}`);
-        this._input_field.value = text;
-        this._input_field.focus();
-    }
-}
+    let stm_icon = new SpeakToMeIcon();
 
-const on_spm_icon_click = (event) => {
-    let constraints = { audio: true };
-    let chunks = [];
+    // Webrtc_Vad integration
+    SpeakToMeVad = function SpeakToMeVad() {
+        this.webrtc_main = Module.cwrap("main");
+        this.webrtc_main();
+        this.webrtc_setmode = Module.cwrap("setmode", "number", ["number"]);
+        // set_mode defines the aggressiveness degree of the voice activity detection algorithm
+        // for more info see: https://github.com/mozilla/gecko/blob/central/media/webrtc/trunk/webrtc/common_audio/vad/vad_core.h#L68
+        this.webrtc_setmode(3);
+        this.webrtc_process_data = Module.cwrap("process_data", "number", [
+            "number",
+            "number",
+            "number",
+            "number",
+            "number",
+            "number"
+        ]);
+        // frame length that should be passed to the vad engine. Depends on audio sample rate
+        // https://github.com/mozilla/gecko/blob/central/media/webrtc/trunk/webrtc/common_audio/vad/vad_core.h#L106
+        this.sizeBufferVad = 480;
+        // minimum of voice (in milliseconds) that should be captured to be considered voice
+        this.minvoice = 250;
+        // max amount of silence (in milliseconds) that should be captured to be considered end-of-speech
+        this.maxsilence = 1500;
+        // max amount of capturing time (in seconds)
+        this.maxtime = 6;
 
-    navigator.mediaDevices.getUserMedia(constraints)
-        .then(function(stream) {
-            // Build the WebAudio graph we'll be using
-            let audioContext = new AudioContext();
-            let sourceNode = audioContext.createMediaStreamSource(stream);
-            let analyzerNode = audioContext.createAnalyser();
-            let outputNode = audioContext.createMediaStreamDestination();
-            // make sure we're doing mono everywhere
-            sourceNode.channelCount = 1;
-            analyzerNode.channelCount = 1;
-            outputNode.channelCount = 1;
-            // connect the nodes together
-            sourceNode.connect(analyzerNode);
-            analyzerNode.connect(outputNode);
-            // and set up the recorder
-            let options = {
-                audioBitsPerSecond : 16000,
-                mimeType : "audio/ogg"
+        this.reset = function() {
+            this.buffer_vad = new Int16Array(this.sizeBufferVad);
+            this.leftovers = 0;
+            this.finishedvoice = false;
+            this.samplesvoice = 0;
+            this.samplessilence = 0;
+            this.touchedvoice = false;
+            this.touchedsilence = false;
+            this.dtantes = Date.now();
+            this.dtantesmili = Date.now();
+            this.raisenovoice = false;
+            this.done = false;
+        };
+        // function that returns if the specified buffer has silence of speech
+        this.isSilence = function(buffer_pcm) {
+            // Get data byte size, allocate memory on Emscripten heap, and get pointer
+            let nDataBytes = buffer_pcm.length * buffer_pcm.BYTES_PER_ELEMENT;
+            let dataPtr = Module._malloc(nDataBytes);
+            // Copy data to Emscripten heap (directly accessed from Module.HEAPU8)
+            let dataHeap = new Uint8Array(
+                Module.HEAPU8.buffer,
+                dataPtr,
+                nDataBytes
+            );
+            dataHeap.set(new Uint8Array(buffer_pcm.buffer));
+            // Call function and get result
+            let result = this.webrtc_process_data(
+                dataHeap.byteOffset,
+                buffer_pcm.length,
+                48000,
+                buffer_pcm[0],
+                buffer_pcm[100],
+                buffer_pcm[2000]
+            );
+            // Free memory
+            Module._free(dataHeap.byteOffset);
+            return result;
+        };
+
+        this.floatTo16BitPCM = function(output, input) {
+            for (let i = 0; i < input.length; i++) {
+                let s = Math.max(-1, Math.min(1, input[i]));
+                output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
             }
+        };
 
-            // VAD initializations
-            // console.log("Sample rate: ", audioContext.sampleRate);
-            let bufferSize = 2048;
-            //create a javascript node
-            let scriptprocessor = audioContext.createScriptProcessor(bufferSize, 1, 1);
-            // specify the processing function
-            stm_vad.reset();
-            scriptprocessor.onaudioprocess = stm_vad.recorderProcess;
-            stm_vad.stopGum = () => {
-                console.log("stopGum");
-                mediaRecorder.stop();
-                sourceNode.disconnect(scriptprocessor);
-                sourceNode.disconnect(analyzerNode);
-                analyzerNode.disconnect(outputNode);
-            }
-            // connect stream to our recorder
-            sourceNode.connect(scriptprocessor);
-
-            // MediaRecorder initialization
-            let mediaRecorder = new MediaRecorder(outputNode.stream, options);
-            SpeakToMePopup.showAt(event.clientX, event.clientY);
-
-            SpeakToMePopup.wait_for_stop().then(() => {
-                mediaRecorder.stop();
-            });
-
-            document.getElementById("stm-levels").hidden = false;
-            visualize(analyzerNode);
-
-            mediaRecorder.start();
-
-            mediaRecorder.onstop = (e) => {
-                document.getElementById("stm-levels").hidden = true;
-                console.log("mediaRecorder onStop");
-                // We stopped the recording, send the content to the STT server.
-                mediaRecorder = null;
-                audioContext = null;
-                sourceNode = null;
-                analyzerNode = null;
-                outputNode = null;
-                stream = null;
-                scriptprocessor = null;
-
-                let blob = new Blob(chunks, { "type" : "audio/ogg; codecs=opus" });
-                chunks = [];
-
-                if (LOCAL_TEST) {
-                    let json = JSON.parse('{"status":"ok","data":[{"confidence":0.807493,"text":"PLEASE ADD MILK TO MY SHOPPING LIST"},{"confidence":0.906263,"text":"PLEASE AT MILK TO MY SHOPPING LIST"},{"confidence":0.904414,"text":"PLEASE ET MILK TO MY SHOPPING LIST"}]}');
-                    if (json.status == "ok") {
-                        display_options(json.data);
-                    }
-                    return;
-                }
-
-            fetch(stt_server_url, {
-                method: "POST",
-                body: blob
-                })
-            .then((response) => { return response.json(); })
-            .then((json) => {
-                console.log(`Got STT result: ${JSON.stringify(json)}`);
-                if (json.status == "ok") {
-                    display_options(json.data);
-                }
-            })
-            .catch((error) => {
-                console.error(`Fetch error: ${error}`);
-            });
-        }
-
-        mediaRecorder.ondataavailable = (e) => {
-            chunks.push(e.data);
-        }
-    })
-    .catch(function(err) {
-        console.log(`Recording error: ${err}`);
-    });
-}
-
-const display_options = (items) => {
-    // Filter the array for empty items and normalize the text.
-    let data = items.filter((item) => { return item.text != ""; })
-                    .map((item) => { return { confidence: item.confidence,
-                                              text: item.text.toLowerCase()
-                                             } });
-
-    if (data.length == 0) {
-        // TODO: display some failure notification to the user?
-        SpeakToMePopup.hide();
-        return;
-    }
-
-    // if the first result has a high enough confidence, just
-    // use it directly.
-    if (data[0].confidence > 0.90) {
-        stm_icon.set_input(data[0].text);
-        SpeakToMePopup.hide();
-        return;
-    }
-
-    SpeakToMePopup.choose_item(data).then((text) => {
-        stm_icon.set_input(text);
-        // Once a choice is made, close the popup.
-        SpeakToMePopup.hide();
-    });
-}
-
-SpeakToMePopup.init();
-
-let stm_icon = new SpeakToMeIcon();
-
-// Webrtc_Vad integration
-SpeakToMeVad = function SpeakToMeVad() {
-
-    this.webrtc_main = Module.cwrap("main");
-    this.webrtc_main();
-    this.webrtc_setmode = Module.cwrap("setmode", "number", ["number"]);
-    // set_mode defines the aggressiveness degree of the voice activity detection algorithm
-    // for more info see: https://github.com/mozilla/gecko/blob/central/media/webrtc/trunk/webrtc/common_audio/vad/vad_core.h#L68
-    this.webrtc_setmode(3);
-    this.webrtc_process_data = Module.cwrap("process_data", "number", ["number", "number", "number", "number", "number", "number"]);
-    // frame length that should be passed to the vad engine. Depends on audio sample rate
-    // https://github.com/mozilla/gecko/blob/central/media/webrtc/trunk/webrtc/common_audio/vad/vad_core.h#L106
-    this.sizeBufferVad = 480;
-    // minimum of voice (in milliseconds) that should be captured to be considered voice
-    this.minvoice = 250;
-    // max amount of silence (in milliseconds) that should be captured to be considered end-of-speech
-    this.maxsilence = 1500;
-    // max amount of capturing time (in seconds)
-    this.maxtime = 6;
-
-    this.reset = function() {
-        this.buffer_vad = new Int16Array(this.sizeBufferVad);
-        this.leftovers = 0;
-        this.finishedvoice = false;
-        this.samplesvoice = 0 ;
-        this.samplessilence = 0 ;
-        this.touchedvoice = false;
-        this.touchedsilence = false;
-        this.dtantes = Date.now();
-        this.dtantesmili = Date.now();
-        this.raisenovoice = false;
-        this.done = false;
-    }
-    // function that returns if the specified buffer has silence of speech
-    this.isSilence = function(buffer_pcm) {
-        // Get data byte size, allocate memory on Emscripten heap, and get pointer
-        let nDataBytes = buffer_pcm.length * buffer_pcm.BYTES_PER_ELEMENT;
-        let dataPtr = Module._malloc(nDataBytes);
-        // Copy data to Emscripten heap (directly accessed from Module.HEAPU8)
-        let dataHeap = new Uint8Array(Module.HEAPU8.buffer, dataPtr, nDataBytes);
-        dataHeap.set(new Uint8Array(buffer_pcm.buffer));
-        // Call function and get result
-        let result = this.webrtc_process_data(dataHeap.byteOffset, buffer_pcm.length, 48000, buffer_pcm[0], buffer_pcm[100], buffer_pcm[2000]);
-        // Free memory
-        Module._free(dataHeap.byteOffset);
-        return result;
-    }
-
-    this.floatTo16BitPCM = function(output, input) {
-        for (let i = 0; i < input.length; i++) {
-            let s = Math.max(-1, Math.min(1, input[i]));
-            output[i] =  s < 0 ? s * 0x8000 : s * 0x7FFF;
-        }
-    }
-
-    this.recorderProcess = function(e) {
-        let buffer_pcm = new Int16Array(e.inputBuffer.getChannelData(0).length);
-        stm_vad.floatTo16BitPCM(buffer_pcm, e.inputBuffer.getChannelData(0));
-        // algorithm used to determine if the user stopped speaking or not
-        for (let i = 0; i < Math.ceil(buffer_pcm.length/stm_vad.sizeBufferVad) && !stm_vad.done; i++) {
-            let start = i * stm_vad.sizeBufferVad;
-            let end = start+stm_vad.sizeBufferVad;
-            if ((start + stm_vad.sizeBufferVad) > buffer_pcm.length) {
-                // store to the next buffer
-                stm_vad.buffer_vad.set(buffer_pcm.slice(start));
-                stm_vad.leftovers =  buffer_pcm.length - start;
-            } else {
-                if (stm_vad.leftovers > 0) {
-                    // we have this.leftovers from previous array
-                    end = end - this.leftovers;
-                    stm_vad.buffer_vad.set((buffer_pcm.slice(start, end)), stm_vad.leftovers);
-                    stm_vad.leftovers =  0;
+        this.recorderProcess = function(e) {
+            let buffer_pcm = new Int16Array(
+                e.inputBuffer.getChannelData(0).length
+            );
+            stm_vad.floatTo16BitPCM(
+                buffer_pcm,
+                e.inputBuffer.getChannelData(0)
+            );
+            // algorithm used to determine if the user stopped speaking or not
+            for (
+                let i = 0;
+                i < Math.ceil(buffer_pcm.length / stm_vad.sizeBufferVad) &&
+                !stm_vad.done;
+                i++
+            ) {
+                let start = i * stm_vad.sizeBufferVad;
+                let end = start + stm_vad.sizeBufferVad;
+                if (start + stm_vad.sizeBufferVad > buffer_pcm.length) {
+                    // store to the next buffer
+                    stm_vad.buffer_vad.set(buffer_pcm.slice(start));
+                    stm_vad.leftovers = buffer_pcm.length - start;
                 } else {
-                    // send to the vad
-                    stm_vad.buffer_vad.set(buffer_pcm.slice(start, end));
-                }
-                let vad = stm_vad.isSilence(stm_vad.buffer_vad);
-                stm_vad.buffer_vad = new Int16Array(stm_vad.sizeBufferVad);
-                let dtdepois = Date.now();
-                if (vad == 0) {
-                    if (stm_vad.touchedvoice) {
-                        stm_vad.samplessilence += dtdepois - stm_vad.dtantesmili;
-                        if (stm_vad.samplessilence >  stm_vad.maxsilence) {
-                            stm_vad.touchedsilence = true;
+                    if (stm_vad.leftovers > 0) {
+                        // we have this.leftovers from previous array
+                        end = end - this.leftovers;
+                        stm_vad.buffer_vad.set(
+                            buffer_pcm.slice(start, end),
+                            stm_vad.leftovers
+                        );
+                        stm_vad.leftovers = 0;
+                    } else {
+                        // send to the vad
+                        stm_vad.buffer_vad.set(buffer_pcm.slice(start, end));
+                    }
+                    let vad = stm_vad.isSilence(stm_vad.buffer_vad);
+                    stm_vad.buffer_vad = new Int16Array(stm_vad.sizeBufferVad);
+                    let dtdepois = Date.now();
+                    if (vad === 0) {
+                        if (stm_vad.touchedvoice) {
+                            stm_vad.samplessilence +=
+                                dtdepois - stm_vad.dtantesmili;
+                            if (stm_vad.samplessilence > stm_vad.maxsilence) {
+                                stm_vad.touchedsilence = true;
+                            }
+                        }
+                    } else {
+                        stm_vad.samplesvoice += dtdepois - stm_vad.dtantesmili;
+                        if (stm_vad.samplesvoice > stm_vad.minvoice) {
+                            stm_vad.touchedvoice = true;
+                        }
+                    }
+                    stm_vad.dtantesmili = dtdepois;
+                    if (stm_vad.touchedvoice && stm_vad.touchedsilence) {
+                        stm_vad.finishedvoice = true;
+                    }
+                    if (stm_vad.finishedvoice) {
+                        stm_vad.done = true;
+                        stm_vad.goCloud("GoCloud finishedvoice");
+                    }
+                    if ((dtdepois - stm_vad.dtantes) / 1000 > stm_vad.maxtime) {
+                        stm_vad.done = true;
+                        if (stm_vad.touchedvoice) {
+                            stm_vad.goCloud("GoCloud timeout");
+                        } else {
+                            stm_vad.goCloud("Raise novoice");
+                            stm_vad.raisenovoice = true;
                         }
                     }
                 }
-                else {
-                    stm_vad.samplesvoice  += dtdepois - stm_vad.dtantesmili;
-                    if (stm_vad.samplesvoice >  stm_vad.minvoice) {
-                        stm_vad.touchedvoice = true;
-                    }
-                }
-                stm_vad.dtantesmili = dtdepois;
-                if (stm_vad.touchedvoice && stm_vad.touchedsilence) {
-                    stm_vad.finishedvoice = true;
-                }
-                if (stm_vad.finishedvoice) {
-                    stm_vad.done = true;
-                    stm_vad.goCloud("GoCloud finishedvoice");
-                }
-                if ((dtdepois - stm_vad.dtantes)/1000 > stm_vad.maxtime ) {
-                    stm_vad.done = true;
-                    if (stm_vad.touchedvoice) {
-                        stm_vad.goCloud("GoCloud timeout");
-                    } else {
-                        stm_vad.goCloud("Raise novoice");
-                        stm_vad.raisenovoice = true;
-                    }
-                }
             }
-        }
-    }
+        };
 
-    this.goCloud = function(why) {
-        console.log(why);
-        this.stopGum();
-    }
-    console.log("speakToMeVad created()");
-}
-
+        this.goCloud = function(why) {
+            console.log(why);
+            this.stopGum();
+        };
+        console.log("speakToMeVad created()");
+    };
 })();
 
 // Creation of the configuration object
@@ -478,18 +546,25 @@ var Module = {
             console.log("[webrtc_vad.js print]", text);
         };
     })(),
-    printErr: function(text) {
+    printErr(text) {
         console.error("[webrtc_vad.js error]", text);
     },
-    canvas: (function() {
-    })(),
-    setStatus: function(text) {
+    canvas: (function() {})(),
+    setStatus(text) {
         console.log("[webrtc_vad.js status] ", text);
     },
     totalDependencies: 0,
-    monitorRunDependencies: function(left) {
+    monitorRunDependencies(left) {
         this.totalDependencies = Math.max(this.totalDependencies, left);
-        Module.setStatus(left ? "Preparing... (" + (this.totalDependencies-left) + "/" + this.totalDependencies + ")" : "All downloads complete.");
+        Module.setStatus(
+            left
+                ? "Preparing... (" +
+                  (this.totalDependencies - left) +
+                  "/" +
+                  this.totalDependencies +
+                  ")"
+                : "All downloads complete."
+        );
     }
 };
 var stm_vad;

--- a/extension/main.css
+++ b/extension/main.css
@@ -4,7 +4,7 @@
 
 #stm-popup {
     background-color: white;
-    display:none;
+    display: none;
     position: absolute;
     top: 0;
     left: 0;
@@ -17,7 +17,9 @@
     box-shadow: 0 0 2em orange !important;
 }
 
-#stm-stop.hidden, #stm-list.hidden, .stm-icon.hidden {
+#stm-stop.hidden,
+#stm-list.hidden,
+.stm-icon.hidden {
     display: none;
 }
 
@@ -30,7 +32,7 @@ ul.stm-list {
     cursor: pointer;
 }
 
-.stm-list li:nth-child(odd)	{
+.stm-list li:nth-child(odd) {
     background-color: lightgray;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "description": "This is a simple WebExtension that adds support to use Speech To Text as an input method in web pages.",
   "name": "speak-to-me",
+  "description": "This is a simple WebExtension that adds support to use Speech To Text as an input method in web pages.",
   "version": "1.0.0",
   "author": {
     "name": "Fabrice Desré",
@@ -10,10 +10,11 @@
     "url": "https://github.com/mozilla/speaktome/issues"
   },
   "devDependencies": {
-    "eslint": "3.19.0",
+    "eslint": "4.1.1",
     "eslint-plugin-mozilla": "0.3.2",
-    "prettier": "1.2.2",
-    "web-ext": "1.9.1"
+    "npm-run-all": "4.0.2",
+    "prettier": "1.5.2",
+    "web-ext": "1.10.0"
   },
   "homepage": "https://github.com/mozilla/speaktome#readme",
   "keywords": [],
@@ -24,7 +25,8 @@
   },
   "scripts": {
     "build": "web-ext build -s extension",
-    "format:js": "prettier 'extension/content.js' --tab-width=4 --write",
+    "format": "prettier 'extension/!(webrtc_vad).{js,css}' --tab-width=4 --write",
+    "lint": "npm-run-all lint:*",
     "lint:extension": "web-ext lint -s extension --ignore-files webrtc_vad.js --self-hosted",
     "lint:js": "eslint extension",
     "once": "web-ext run -s extension"


### PR DESCRIPTION
**prettier** now supports basic CSS formatting.

Also, tweaked a couple npm script names. Now running `npm run format` auto-formats JavaScript _and_ CSS.

A new script, `npm run lint`, will lint CSS and JavaScript at the same time instead of having to run `npm run lint:css` and `npm run lint:js` separately (although you _can_ still run them separately if you wish).

---

Looks like a potential scoping issue w/ `SpeakToMeVad`. I think it's defined in an IIFE, but then accessed later outside of that scope in some module code. Slightly modified `npm run lint:js` output is as follows (minus the `no-console` warnings):

```sh
$ npm run lint:js

> speak-to-me@1.0.0 lint:js /Users/pdehaan/dev/github/mozilla/speaktome
> eslint extension

/Users/pdehaan/dev/github/mozilla/speaktome/extension/content.js
  101:5   warning  Unexpected 'todo' comment            no-warning-comments
  142:1   warning  Unexpected 'todo' comment            no-warning-comments
  177:18  error    Expected '!==' and instead saw '!='  eqeqeq
  181:17  error    Expected '!==' and instead saw '!='  eqeqeq
  285:37  error    Expected '===' and instead saw '=='  eqeqeq
  298:33  error    Expected '===' and instead saw '=='  eqeqeq
  318:58  error    Expected '!==' and instead saw '!='  eqeqeq
  323:21  error    Expected '===' and instead saw '=='  eqeqeq
  324:9   warning  Unexpected 'todo' comment            no-warning-comments
  349:1   error    'SpeakToMeVad' is not defined        no-undef
  427:25  error    Expected '===' and instead saw '=='  eqeqeq
  498:5   warning  Unexpected 'todo' comment            no-warning-comments
  508:19  error    'SpeakToMeVad' is not defined        no-undef

✖ 13 problems (9 errors, 4 warnings)
```
