### PR TITLE
Add in url for no-popup duckduckgo.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -28,6 +28,8 @@
         "https://www.google.ca/",
         "https://duckduckgo.com/",
         "https://duckduckgo.com/*",
+        "https://start.duckduckgo.com/",
+        "https://start.duckduckgo.com/*",
         "https://www.yahoo.com/",
         "https://www.yahoo.com/*",
         "https://search.yahoo.com/*",


### PR DESCRIPTION
There is a version of duckduckgo without popups (https://start.duckduckgo.com/). I added this to the list of supported sites. 
I don't know if this is all I need or if something more complicated needs to be done.