### PR TITLE
Html escape text

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 extension/bodymovin.js
-extension/purify.min.js
 extension/testpilot-ga.js
 extension/webrtc_vad.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 web-ext-artifacts
 npm-debug.log
 extension/bodymovin.js
-extension/purify.min.js
 extension/testpilot-ga.js

--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -3,4 +3,3 @@ set -ex
 
 cp node_modules/bodymovin/build/player/bodymovin.js extension/bodymovin.js
 cp node_modules/testpilot-ga/dist/index.js extension/testpilot-ga.js
-cp node_modules/dompurify/dist/purify.min.js extension/purify.min.js

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -463,7 +463,7 @@
         "https://www.bing.com/*",
         "https://www.bing.com/"
       ],
-      "js": ["purify.min.js", "bodymovin.js", "metrics.js", "content.js",
+      "js": ["bodymovin.js", "metrics.js", "content.js",
         "webrtc_vad.js"],
       "css": ["main.css"]
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "bodymovin": "4.9.0",
-    "dompurify": "0.9.0",
     "testpilot-ga": "0.3.0"
   },
   "homepage": "https://github.com/mozilla/speaktome#readme",
@@ -31,9 +30,9 @@
   },
   "scripts": {
     "build": "web-ext build -s extension --overwrite-dest",
-    "format": "prettier 'extension/!(bodymovin|purify.min|testpilot-ga|webrtc_vad).{js,css}' --tab-width=4 --write",
+    "format": "prettier 'extension/!(bodymovin|testpilot-ga|webrtc_vad).{js,css}' --tab-width=4 --write",
     "lint": "npm-run-all lint:*",
-    "lint:extension": "web-ext lint -s extension --ignore-files bodymovin.js purify.min.js testpilot-ga.js webrtc_vad.js --self-hosted",
+    "lint:extension": "web-ext lint -s extension --ignore-files bodymovin.js testpilot-ga.js webrtc_vad.js --self-hosted",
     "lint:js": "eslint extension",
     "once": "web-ext run -s extension",
     "package": "npm run build && mv web-ext-artifacts/*.zip addon.xpi",


### PR DESCRIPTION
per discussion in https://github.com/mozilla/speaktome/pull/258 

Assuming `item.confidence` and `item.text` are always text and don't need to insert elements into the DOM then we can html escape them instead.

Also, as Andre pointed out errorMsg is always text (since we set it's value to one of a few options just above), but we'll escape it anyway in case the returned errors change or get passed through at some point.

This lets us remove DOMPurify and make the extensions slightly smaller.

r? @andrenatal 